### PR TITLE
Don't prepend a newline to ruleset files

### DIFF
--- a/src/https_everywhere_checker/check_rules.py
+++ b/src/https_everywhere_checker/check_rules.py
@@ -152,7 +152,7 @@ def disableRuleset(ruleset, problems):
 	# If there's not already a comment section at the beginning, add one.
 	if not re.search("^<!--", contents):
 		contents = "<!--\n-->\n" + contents
-	problemStatement = ("""
+	problemStatement = ("""\
 <!--
 Disabled by https-everywhere-checker because:
 %s


### PR DESCRIPTION
When disabling a ruleset, the checker prepends an extra newline to the beginning of the file before the `<!--`. This patch should fix that.

It's obviously extremely trivial, but slightly annoying when editing the files.

<3
