### PR TITLE
Add config for http checking of non-default_offs but no coverage check

### DIFF
--- a/http.checker.config
+++ b/http.checker.config
@@ -1,0 +1,33 @@
+# Config for checking connections of non-default_off rules
+# without checking coverage.
+[rulesets]
+# Directory with XML files describing HTTPS Everywhere rulesets
+rulesdir = src/chrome/content/rules
+check_coverage = false
+auto_disable = false
+include_default_off = false
+
+[certificates]
+# Certificate trust anchors for checking chains in HTTPS connections
+basedir = test/rules/platform_certs
+
+[http]
+user_agent = Mozilla/5.0 (X11; Linux x86_64; rv:36.0) Gecko/20100101 Firefox/36.0
+enabled = true
+connect_timeout = 10
+read_timeout = 15
+redirect_depth = 10
+threads = 40
+fetch_in_subprocess = false
+
+[log]
+logfile = -
+loglevel = info
+
+[thresholds]
+metric = markup
+max_distance = 0.1
+
+[debug]
+graphviz_file = HTEC_trie.dot
+exit_after_dump = true


### PR DESCRIPTION
For use with https://github.com/EFForg/https-everywhere/pull/3107. Note that https://github.com/EFForg/https-everywhere/pull/3107/files#diff-814349d09423b7cb22cfff0e20cb1e95R28 could have been done a bit smoother if we had something similar to https://github.com/jsha/https-everywhere-checker/blob/updates/src/https_everywhere_checker/check_rules.py#L412 but for fetch errors; currently the script returns exit code 0 even on errors.
